### PR TITLE
Added creation timestamp to metric defs

### DIFF
--- a/files/default/mon_metrics_schema.sql
+++ b/files/default/mon_metrics_schema.sql
@@ -15,9 +15,10 @@ CREATE TABLE MonMetrics.Definitions(
     name VARCHAR(255) NOT NULL,
     tenant_id VARCHAR(255) NOT NULL,
     region VARCHAR(255) NOT NULL,
+    time_stamp TIMESTAMP NOT NULL
     PRIMARY KEY(id),
     CONSTRAINT MetricsDefinitionsConstraint UNIQUE(name, tenant_id, region)
-);
+) PARTITION BY EXTRACT('year' FROM time_stamp)*10000 + EXTRACT('month' FROM time_stamp)*100 + EXTRACT('day' FROM time_stamp);
 
 CREATE TABLE MonMetrics.Dimensions (
     dimension_set_id BINARY(20) NOT NULL,
@@ -40,7 +41,7 @@ CREATE PROJECTION Measurements_DBD_1_rep_MonMetrics /*+createtype(D)*/
 (
  id ENCODING AUTO, 
  definition_dimensions_id ENCODING RLE,
- time_stamp ENCODING DELTAVAL, 
+ time_stamp ENCODING DELTAVAL,
  value ENCODING AUTO
 )
 AS
@@ -59,13 +60,15 @@ CREATE PROJECTION Definitions_DBD_2_rep_MonMetrics /*+createtype(D)*/
  id ENCODING RLE, 
  name ENCODING AUTO,
  tenant_id ENCODING RLE, 
- region ENCODING RLE
+ region ENCODING RLE,
+ time_stamp ENCODING DELTAVAL
 )
 AS
  SELECT id, 
         name, 
         tenant_id, 
-        region
+        region,
+        time_stamp
  FROM MonMetrics.Definitions 
  ORDER BY id,
           tenant_id,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'hpcs-mon@hp.com'
 license          'All rights reserved'
 description      'Installs/Configures vertica'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.11'
+version          '1.1.12'
 depends          'hostsfile'
 depends          'sysctl'
 depends          'python'  # Used for the backup recipe


### PR DESCRIPTION
This PR adds metric definition creation timestamps to support API calls that fetch newly created metrics.
